### PR TITLE
upgrade to babel6

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,0 @@
-{
-  "stage": 0,
-  "optional": "runtime"
-}

--- a/package.json
+++ b/package.json
@@ -41,18 +41,31 @@
   },
   "homepage": "https://github.com/salsita/redux-side-effects#readme",
   "devDependencies": {
-    "babel": "^5.8.23",
-    "babel-core": "^5.8.25",
-    "babel-eslint": "^4.1.3",
-    "babel-runtime": "^5.8.25",
+    "babel": "^6.3.26",
+    "babel-cli": "^6.4.5",
+    "babel-core": "^6.4.5",
+    "babel-eslint": "^5.0.0-beta6",
+    "babel-plugin-transform-runtime": "^6.4.3",
+    "babel-preset-es2015": "^6.3.13",
+    "babel-preset-stage-0": "^6.3.13",
+    "babel-runtime": "^6.3.19",
     "chai": "^3.4.1",
     "eslint": "^1.9.0",
-    "isparta": "^3.0.3",
+    "isparta": "^4.0.0",
     "mocha": "^2.2.5",
     "redux": "^3.0.4",
     "sinon": "^1.17.2"
   },
   "peerDependencies": {
-    "babel-runtime": "^5.8.25"
+    "babel-runtime": "^6.3.19"
+  },
+  "babel": {
+    "presets": [
+      "es2015",
+      "stage-0"
+    ],
+    "plugins": [
+      "transform-runtime"
+    ]
   }
 }


### PR DESCRIPTION
1 - babel has been upgraded to babel6
2 - .babelrc content has been moved to package.json, imo it's better than separate config.
